### PR TITLE
optype 0.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-optype-green.svg)](https://anaconda.org/conda-forge/optype) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/optype.svg)](https://anaconda.org/conda-forge/optype) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/optype.svg)](https://anaconda.org/conda-forge/optype) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/optype.svg)](https://anaconda.org/conda-forge/optype) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-optype--numpy-green.svg)](https://anaconda.org/conda-forge/optype-numpy) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/optype-numpy.svg)](https://anaconda.org/conda-forge/optype-numpy) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/optype-numpy.svg)](https://anaconda.org/conda-forge/optype-numpy) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/optype-numpy.svg)](https://anaconda.org/conda-forge/optype-numpy) |
 
 Installing optype
 =================
@@ -45,16 +46,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `optype` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `optype, optype-numpy` can be installed with `conda`:
 
 ```
-conda install optype
+conda install optype optype-numpy
 ```
 
 or with `mamba`:
 
 ```
-mamba install optype
+mamba install optype optype-numpy
 ```
 
 It is possible to list all of the versions of `optype` available on your platform with `conda`:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,38 +2,70 @@ schema_version: 1
 
 context:
   name: optype
-  version: "0.12.2"
+  version: "0.13.1"
   python_min: "3.11"
+  numpy_min: "1.25"
 
-package:
-  name: ${{ name|lower }}
+recipe:
+  name: ${{ name }}-split
   version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/optype-${{ version }}.tar.gz
-  sha256: 3f53a89f56f0ea23be4d212611dce0f3a2a8946543a9a72783e349c49b232934
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}//${{ name }}-${{ version }}.tar.gz
+  sha256: 9b1d590597b0c093faf5253e38238c5a5e1a1f9afb04530836c38ac94fdd5cf6
 
 build:
   number: 0
-  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  noarch: python
 
-requirements:
-  host:
-    - python ${{ python_min }}.*
-    - uv-build
-    - pip
-  run:
-    - python >=${{ python_min }}
-    # needed for python <3.13, not using a selector to enable noarch
-    - typing-extensions >=4.10 
+outputs:
+  - package:
+      name: ${{ name }}
+    build:
+      script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+      noarch: python
+    requirements:
+      host:
+        - python ${{ python_min }}.*
+        - uv-build
+        - pip
+      run:
+        - python >=${{ python_min }}
+        # needed for python <3.13, not using a selector to enable noarch
+        - typing-extensions >=4.10 
 
-tests:
-  - python:
-      imports:
-        - optype
-      pip_check: true
-      python_version: ${{ python_min }}.*
+    tests:
+      - python:
+          imports:
+            - optype
+          pip_check: true
+          python_version: ${{ python_min }}.*
+
+  # analogue of PyPI's `optype[numpy]`
+  - package:
+      name: ${{ name }}-numpy
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python ${{ python_min }}.*
+      run:
+        - python >=${{ python_min }}
+        - numpy >=${{ numpy_min }}
+        - numpy-typing-compat >=${{ numpy_min }}
+        - ${{ pin_subpackage('optype', exact=True) }}
+    tests:
+      - python:
+          imports:
+            - optype
+      - files:
+          source:
+            - pyproject.toml
+        requirements:
+          run:
+            - python ${{ python_min }}.*
+        script:
+          # raises if numpy-typing-compat is not installed or the wrong version
+          - python -c "import optype.numpy"
 
 about:
   license: BSD-3-Clause

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,7 +11,7 @@ recipe:
   version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}//${{ name }}-${{ version }}.tar.gz
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
   sha256: 9b1d590597b0c093faf5253e38238c5a5e1a1f9afb04530836c38ac94fdd5cf6
 
 build:


### PR DESCRIPTION
this adds `optype-numpy`, and supersedes #25

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
